### PR TITLE
New jquery-rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'ffi', '1.0.9'
 
 gem 'sqlite3-ruby', :require => 'sqlite3'
 gem 'will_paginate'
-gem 'jquery-rails'
+gem 'jquery-rails', '2.0.3'
 
 group :assets do
   gem 'sass-rails', '~> 3.2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,8 +55,8 @@ GEM
     hike (1.2.1)
     i18n (0.6.0)
     journey (1.0.3)
-    jquery-rails (2.0.0)
-      railties (>= 3.2.0.beta, < 5.0)
+    jquery-rails (2.0.3)
+      railties (>= 3.1.0, < 5.0)
       thor (~> 0.14)
     json (1.6.5)
     json_pure (1.6.5)
@@ -148,7 +148,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.2)
   cucumber
   ffi (= 1.0.9)
-  jquery-rails
+  jquery-rails (= 2.0.3)
   json_pure
   page-object
   rails (= 3.2.1)


### PR DESCRIPTION
I tried to install the dependencies and bundle was unable to find jquery-rails 2.0.0.

Took the safe way and upgraded to the latest point release instead of trying 2.1.x.
